### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -32,5 +32,6 @@ ASSETS_AUTO_BUILD = False
 PACKAGES = [
     'invenio_sequencegenerator',
     'invenio_upgrader',
+    'invenio_ext',
     'invenio_base',
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -63,6 +63,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/invenio_sequencegenerator/models.py
+++ b/invenio_sequencegenerator/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2014 CERN.
+# Copyright (C) 2012, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,7 @@
 SeqUtils database models.
 """
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 
 class SeqSTORE(db.Model):

--- a/invenio_sequencegenerator/scripts/bibtex.py
+++ b/invenio_sequencegenerator/scripts/bibtex.py
@@ -17,11 +17,9 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-Texkey: Look for records without a texkey and generate one
-"""
+"""Texkey: Look for records without a texkey and generate one."""
 
-from invenio.base.factory import with_app_context
+from invenio_base.factory import with_app_context
 
 
 @with_app_context()

--- a/invenio_sequencegenerator/texkey.py
+++ b/invenio_sequencegenerator/texkey.py
@@ -27,8 +27,8 @@ import string
 
 import time
 
-from invenio.config import CFG_TMPSHAREDDIR, CFG_VERSION
-from invenio.legacy.search_engine import get_record as get_bibrecord
+from tempfile import mkstemp
+
 from invenio.legacy.bibrecord import create_record, \
     field_get_subfield_values, print_rec, record_add_field, \
     record_get_field_instances, record_get_field_value
@@ -37,8 +37,9 @@ from invenio.legacy.bibsched.bibtask import task_init, \
     task_update_progress, write_message
 from invenio.legacy.dbquery import run_sql
 from invenio.legacy.search_engine import get_record, perform_request_search
+from invenio.legacy.search_engine import get_record as get_bibrecord
 
-from tempfile import mkstemp
+from invenio_base.globals import cfg
 
 from unidecode import unidecode
 
@@ -217,7 +218,7 @@ def submit_task(to_submit, mode, sequence_id):
     :rtype: int
     """
     (temp_fd, temp_path) = mkstemp(prefix=PREFIX,
-                                   dir=CFG_TMPSHAREDDIR)
+                                   dir=cfg['CFG_TMPSHAREDDIR'])
     temp_file = os.fdopen(temp_fd, 'w')
     temp_file.write('<?xml version="1.0" encoding="UTF-8"?>')
     temp_file.write('<collection>')
@@ -362,7 +363,7 @@ def main():
               authorization_msg="Texkey generator task submission",
               description=DESCRIPTION,
               help_specific_usage=HELP_MESSAGE,
-              version="Invenio v%s" % CFG_VERSION,
+              version="Invenio v%s" % cfg['CFG_VERSION'],
               specific_params=("", []),
               # task_submit_elaborate_specific_parameter_fnc=parse_option,
               # task_submit_check_options_fnc=check_options,

--- a/invenio_sequencegenerator/upgrades/sequencegenerator_2014_03_18_id_increase.py
+++ b/invenio_sequencegenerator/upgrades/sequencegenerator_2014_03_18_id_increase.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from sqlalchemy import *
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 
 depends_on = []

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_sequencegenerator --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_sequencegenerator --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,6 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,9 +21,5 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,3 +24,4 @@
 
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,3 +23,4 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
-    'Invenio>=2.0.3',
+    'invenio_base>=0.3.0',
     'invenio-ext>=0.1.0',
     'invenio-upgrader>=0.1.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio_base>=0.3.0',
-    'invenio-ext>=0.1.0',
+    'invenio-ext>=0.3.1',
     'invenio-upgrader>=0.1.2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'Invenio>=2.0.3',
+    'invenio-ext>=0.1.0',
 ]
 
 test_requirements = [
@@ -49,6 +50,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ requirements = [
 
 test_requirements = [
     'mock>=1.0.0',
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -75,9 +75,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'Invenio>=2.0.3',
     'invenio-ext>=0.1.0',
+    'invenio-upgrader>=0.1.2',
 ]
 
 test_requirements = [

--- a/tests/test_sequencegenerator.py
+++ b/tests/test_sequencegenerator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio Demosite.
-# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 CERN.
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2015 CERN.
 #
 # Invenio Demosite is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,7 @@
 
 from mock import patch
 
-from invenio.testsuite import InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 from invenio_sequencegenerator.backend import SequenceGenerator
 
@@ -29,14 +29,14 @@ from invenio_sequencegenerator.backend import SequenceGenerator
 def get_bibrecord_mock(_):
     return {'001': [([], ' ', ' ', '1086086', 1)],
             '111': [([('a',
-            'Mock conference'),
-            ('d', '14-16 Sep 2011'),
-            ('x', '2050-09-14'),
-            ('c', 'xxxxx')],
-            ' ',
-            ' ',
-            '',
-            3)],
+                       'Mock conference'),
+                      ('d', '14-16 Sep 2011'),
+                      ('x', '2050-09-14'),
+                      ('c', 'xxxxx')],
+                     ' ',
+                     ' ',
+                     '',
+                     3)],
             '270': [([('m', 'dummy@dummy.com')], ' ', ' ', '', 5)],
             '856': [([('u', 'http://dummy.com/')], '4', ' ', '', 6)],
             '970': [([('a', 'CONF-XXXXXX')], ' ', ' ', '', 2)],
@@ -72,7 +72,7 @@ class TestIntSequenceGeneratorClass(InvenioTestCase):
 class TestCnumSequenceGeneratorClass(InvenioTestCase):
 
     @patch('invenio.legacy.bibedit.utils.get_bibrecord',
-        get_bibrecord_mock)
+           get_bibrecord_mock)
     def test_get_next_cnum(self):
         from invenio_sequencegenerator.cnum import CnumSeq
         from invenio_sequencegenerator.models import SeqSTORE


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
