### PR TITLE
global: proper entry-point registration

### DIFF
--- a/invenio_sequencegenerator/__init__.py
+++ b/invenio_sequencegenerator/__init__.py
@@ -226,6 +226,7 @@ specific playlist, all at once:
 
 from __future__ import absolute_import, print_function
 
+from .ext import InvenioSequenceGenerator
 from .version import __version__
 
-__all__ = ('__version__', )
+__all__ = ('__version__', 'InvenioSequenceGenerator')

--- a/setup.py
+++ b/setup.py
@@ -107,10 +107,6 @@ setup(
             'invenio_sequencegenerator = '
             'invenio_sequencegenerator:InvenioSequenceGenerator',
         ],
-        'invenio_base.blueprints': [
-            'invenio_sequencegenerator = '
-            'invenio_sequencegenerator.ext:blueprint',
-        ],
         'invenio_i18n.translations': [
             'messages = invenio_sequencegenerator',
         ],


### PR DESCRIPTION
* Adds `InvenioSequenceGenerator` extension to the globally exposed
  classes, in order for the entry-point to be registered properly.

* Removes blueprint entry point.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>